### PR TITLE
Uplift smb to 2.2.0-413

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-git clone https://github.com/marcusspangenberg/SymphonyMediaBridge.git
+SMB_VERSION=2.2.0-413
+
+git clone https://github.com/eyevinn/SymphonyMediaBridge.git
 pushd SymphonyMediaBridge
-git checkout marcus/fix_broken_outbound_cleanup
+git ${SMB_VERSION}
 CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" .
 CC=clang CXX=clang++ make -j5
 popd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,13 +3,12 @@
 : "${HTTP_PORT:=8080}"
 : "${LOG_LEVEL:=INFO}"
 : "${LOG_STD_OUT:=true}"
-: "${UDP_PORT:=0}"
-: "${UDP_PORT_LOW:=10006}"
-: "${UDP_PORT_HI:=11000}"
+: "${UDP_PORT:=10000}"
+: "${NUM_UDP_PORTS:=1}"
 : "${TCP_ENABLE:=false}"
 : "${API_KEY:=eyevinn}"
 : "${HTTP_BIND_PORT:=8181}"
-: "${WORKER_THREADS:=7}"
+: "${WORKER_THREADS:=0}"
 : "${INACTIVITY_TIMEOUT:=60000}"
 
 cat > config.json << EOF
@@ -18,8 +17,7 @@ cat > config.json << EOF
   "port": ${HTTP_BIND_PORT},
   "logLevel": "${LOG_LEVEL}",
   "ice.singlePort": ${UDP_PORT},
-  "ice.udpPortRangeLow": ${UDP_PORT_LOW},
-  "ice.udpPortRangeHigh": ${UDP_PORT_HI},
+  "ice.sharedPorts": ${NUM_UDP_PORTS},
   "ice.tcp.enable": ${TCP_ENABLE},
   "ice.publicIpv4": "${IPV4_ADDR}",
   "ice.publicIpv6": "${IPV6_ADDR}",


### PR DESCRIPTION
- Uplift smb to 2.2.0-413
- Move to eyevinn smb repo
- Add support for consecutive UDP ports setting
- Remove deprecated port range
- Default worker threads to 0 to use automatic threads selection based on host cpu count